### PR TITLE
Make links open automatically if missing api key

### DIFF
--- a/src/core/AskChatGPTHandler.ts
+++ b/src/core/AskChatGPTHandler.ts
@@ -114,8 +114,13 @@ export class AskChatGPTHandler {
     }
 
     private static async askChatGPT() {
-        if (logseq.settings.OPENAI_API_KEY.trim() == "")
+         if (logseq.settings.OPENAI_API_KEY.trim() == "") {
+            logseq.showSettingsUI();
+            setTimeout(function () {
+              logseq.App.openExternalLink('https://platform.openai.com/account/api-keys')
+            }, 3000);
             throw {message: "OPENAI_API_KEY is empty. Please go to settings and set it.", type: 'warning'};
+        }
 
         const page = await logseq.Editor.getCurrentPage();
 


### PR DESCRIPTION
One suggestion.  (I haven't been able to verify it, so please make any necessary corrections.)

show settingUI
timeout 3000s : open a link(URL) on browser