### PR TITLE
Update chatgpt-wrapper version to 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^18.2.0",
     "moment": "^2.29.4",
     "mldoc": "^1.5.3",
-    "chatgpt-wrapper": "^1.1.4",
+    "chatgpt-wrapper": "^1.1.5",
     "mustache": "^4.2.0",
     "showdown": "^2.1.0",
     "gpt-3-encoder": "^1.1.4"


### PR DESCRIPTION
"ChatGPT API Endpoint" feature is not working in `chatgpt-wrapper` version 1.1.4. To resolve this problem, upgrade to version 1.1.5.

Reference: https://github.com/TABmk/chatgpt-wrapper/issues/7